### PR TITLE
fix(PromisePool): importing commonjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,22 @@
 {
   "name": "turbo-downloader",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "turbo-downloader",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@supercharge/promise-pool": "^2.1.0",
         "axios": "^0.26.0",
-        "ts-node": "^10.5.0",
-        "typed-emitter": "^2.1.0",
-        "typescript": "^4.5.5"
+        "typed-emitter": "^2.1.0"
       },
       "devDependencies": {
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.0",
+        "@types/node": "^20.10.0",
         "@types/temp": "^0.9.1",
         "@typescript-eslint/eslint-plugin": "^5.12.1",
         "@typescript-eslint/parser": "^5.12.1",
@@ -28,7 +27,9 @@
         "jest": "^27.5.1",
         "prettier": "^2.5.1",
         "temp": "^0.9.4",
-        "ts-jest": "^27.1.3"
+        "ts-jest": "^27.1.3",
+        "ts-node": "^10.9.1",
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -557,18 +558,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/@cspotcode/source-map-support": {
-      "version": "0.7.0",
-      "license": "MIT",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "dependencies": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       },
       "engines": {
         "node": ">=12"
@@ -913,9 +909,10 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.4",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -987,18 +984,22 @@
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.9",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -1090,8 +1091,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "17.0.19",
-      "license": "MIT"
+      "version": "20.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.0.tgz",
+      "integrity": "sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.4.4",
@@ -1355,6 +1361,7 @@
     },
     "node_modules/acorn": {
       "version": "8.7.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -1401,6 +1408,7 @@
     },
     "node_modules/acorn-walk": {
       "version": "8.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -1493,6 +1501,7 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -1811,6 +1820,7 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -1917,6 +1927,7 @@
     },
     "node_modules/diff": {
       "version": "4.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -3665,6 +3676,7 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -4601,10 +4613,12 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.5.0",
-      "license": "MIT",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
       "dependencies": {
-        "@cspotcode/source-map-support": "0.7.0",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -4615,12 +4629,13 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
         "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
@@ -4706,8 +4721,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "license": "Apache-2.0",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4715,6 +4732,12 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -4730,8 +4753,10 @@
       "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "license": "MIT"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
@@ -4939,6 +4964,7 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5287,13 +5313,13 @@
       "version": "0.2.3",
       "dev": true
     },
-    "@cspotcode/source-map-consumer": {
-      "version": "0.8.0"
-    },
     "@cspotcode/source-map-support": {
-      "version": "0.7.0",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "requires": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       }
     },
     "@eslint/eslintrc": {
@@ -5544,7 +5570,9 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.4",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -5595,16 +5623,20 @@
       "dev": true
     },
     "@tsconfig/node10": {
-      "version": "1.0.8"
+      "version": "1.0.8",
+      "dev": true
     },
     "@tsconfig/node12": {
-      "version": "1.0.9"
+      "version": "1.0.9",
+      "dev": true
     },
     "@tsconfig/node14": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "@tsconfig/node16": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.18",
@@ -5684,7 +5716,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.19"
+      "version": "20.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.0.tgz",
+      "integrity": "sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/prettier": {
       "version": "2.4.4",
@@ -5828,7 +5866,8 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.7.0"
+      "version": "8.7.0",
+      "dev": true
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -5854,7 +5893,8 @@
       "requires": {}
     },
     "acorn-walk": {
-      "version": "8.2.0"
+      "version": "8.2.0",
+      "dev": true
     },
     "agent-base": {
       "version": "6.0.2",
@@ -5906,7 +5946,8 @@
       }
     },
     "arg": {
-      "version": "4.1.3"
+      "version": "4.1.3",
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -6120,7 +6161,8 @@
       }
     },
     "create-require": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -6189,7 +6231,8 @@
       "dev": true
     },
     "diff": {
-      "version": "4.0.2"
+      "version": "4.0.2",
+      "dev": true
     },
     "diff-sequences": {
       "version": "27.5.1",
@@ -7333,7 +7376,8 @@
       }
     },
     "make-error": {
-      "version": "1.3.6"
+      "version": "1.3.6",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.12",
@@ -7893,9 +7937,12 @@
       }
     },
     "ts-node": {
-      "version": "10.5.0",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
       "requires": {
-        "@cspotcode/source-map-support": "0.7.0",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -7906,7 +7953,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       }
     },
@@ -7952,7 +7999,16 @@
       }
     },
     "typescript": {
-      "version": "4.5.5"
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",
@@ -7966,7 +8022,10 @@
       "dev": true
     },
     "v8-compile-cache-lib": {
-      "version": "3.0.0"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "v8-to-istanbul": {
       "version": "8.1.1",
@@ -8101,7 +8160,8 @@
       "dev": true
     },
     "yn": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,13 +9,12 @@
   "dependencies": {
     "@supercharge/promise-pool": "^2.1.0",
     "axios": "^0.26.0",
-    "ts-node": "^10.5.0",
-    "typed-emitter": "^2.1.0",
-    "typescript": "^4.5.5"
+    "typed-emitter": "^2.1.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.4.0",
+    "@types/node": "^20.10.0",
     "@types/temp": "^0.9.1",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",
@@ -26,7 +25,9 @@
     "jest": "^27.5.1",
     "prettier": "^2.5.1",
     "temp": "^0.9.4",
-    "ts-jest": "^27.1.3"
+    "ts-jest": "^27.1.3",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "ts-node index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestConfig, ResponseType } from 'axios';
 import fsp from 'node:fs/promises';
 import fs from 'node:fs';
 import { strict as assert } from 'assert';
-import PromisePool from '@supercharge/promise-pool';
+import { PromisePool } from '@supercharge/promise-pool';
 import * as http from 'http';
 import * as https from 'https';
 import * as stream from 'stream';


### PR DESCRIPTION
For some reason, `Jest` doesn't have that issue (probably because jest is written in commonjs) 
When you try to download something you get:

```
TypeError: PromisePool.for is not a function
```

This is an importing issue with packages called `PromisePool`.
I changed from default import to named import and it is working again.